### PR TITLE
Add design-sync config for Quadrant UI (claude.ai/design)

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,52 @@
+# Quadrant UI — design-sync notes
+
+Quadrant is a **Tauri desktop app**, not a published component library, so the
+sync is wired by hand. Key setup (all committed):
+
+- **Barrel entry** `.design-sync/ds-entry.tsx` — every component is a *default*
+  export, so synth mode's `export *` would ship an empty bundle. The barrel
+  re-exports them as named exports and also `import "../src/i18n"` so i18n
+  initializes (react-i18next global instance, no provider). `cfg.entry` points
+  at it; its walk-up also fixes `PKG_DIR` (repo root, since the repo doesn't
+  self-install `node_modules/quadrant-next`).
+- **`cfg.componentSrcMap`** enumerates all 17 components (no `.d.ts` to discover
+  from). Update it when components are added/removed/renamed.
+- **CSS is Tailwind v4.** `.design-sync/build-css.mjs` compiles `src/App.css`
+  with the repo's own `@tailwindcss/postcss` into
+  `.design-sync/quadrant-compiled.css` (= `cfg.cssEntry`) and copies
+  `public/Inter-Font.ttf` beside it. **Re-run `node .design-sync/build-css.mjs`
+  before every (re)build** — the output is gitignored.
+- **Tailwind esbuild shim.** Component CSS files do `@import "tailwindcss"`
+  (a PostCSS directive esbuild can't resolve). `.design-sync/tsconfig.sync.json`
+  (= `cfg.tsconfig`) redirects `tailwindcss` → `.design-sync/tw-shim.css` (empty)
+  so the JS bundle builds. Real styling ships via `cfg.cssEntry`, not these
+  component CSS imports (which are all empty/trivial anyway).
+
+## Known render warns (triaged, not new)
+- `Button`, `CurrentModpackPage` — showed `[RENDER_BLANK]` **only before**
+  authoring; Button now authored. CurrentModpackPage still floor-carded.
+- `ApplyPage`, `SettingsPage` — `[RENDER_ERRORS]: invoke` (browser runtime has
+  no `invoke`). **Non-blocking** — root renders fine (rich chrome); only live
+  data is empty. Expected for any page that fetches on mount.
+
+## Re-sync risks / watch-list
+- **Purged Tailwind.** `quadrant-compiled.css` contains only the utility classes
+  **used in `src`** (Tailwind v4 purges the rest). The palette enumerated in
+  `conventions.md` is verified present, but the design agent using an *arbitrary*
+  utility not in src (e.g. `bg-purple-500`) would get an unstyled result. To make
+  the DS fully general, ship a non-purged/safelisted Tailwind build. Not done —
+  ship-now decision. Revisit if designs come out partly unstyled.
+- **Fidelity of Pages.** `CurrentModpackPage`, `SyncPage`, `ModInstallPage`,
+  `SyncedModpack` render as floor cards (need `invoke` data). `Mod`,
+  `Notifications` render but are data-driven — author previews with real props on
+  a re-sync to lift them. These are the standing incremental-authoring offer.
+- **Only `Button` has an authored preview** (`.design-sync/previews/Button.tsx`).
+  The other 16 ship their auto-render/floor card. This was a "ship it now" run
+  (user: "upload this shit"), not the full author-every-preview pass.
+- **ShareSync context.** `SharePage`/`SyncPage`/`SyncedModpack` consume
+  `ShareSyncPage`'s context — author their previews *inside* `ShareSyncPage`.
+
+## Re-sync procedure
+1. `node .design-sync/build-css.mjs`  (regenerate cssEntry + font)
+2. re-copy staged scripts (`cp -r <skill>/… .ds-sync/`), then
+   `node .ds-sync/resync.mjs --config .design-sync/config.json --node-modules ./node_modules --out ./ds-bundle --remote .design-sync/.cache/remote-sync.json`

--- a/.design-sync/build-css.mjs
+++ b/.design-sync/build-css.mjs
@@ -1,0 +1,38 @@
+/**
+ * design-sync: compile Quadrant's Tailwind v4 stylesheet.
+ *
+ * The app styles with Tailwind v4 (`@import "tailwindcss"` in src/App.css) plus
+ * a handful of custom classes (.input, .center, …) and an Inter @font-face.
+ * The design-sync converter can't run Tailwind, so we precompile the global
+ * stylesheet here with the repo's OWN toolchain (@tailwindcss/postcss) and point
+ * cfg.cssEntry at the result. Re-run this before every (re)build.
+ *
+ *   node .design-sync/build-css.mjs
+ *
+ * Output: .design-sync/quadrant-compiled.css  (+ Inter-Font.ttf copied alongside)
+ */
+import { readFileSync, writeFileSync, copyFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { createRequire } from "node:module";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repo = resolve(here, "..");
+const require = createRequire(resolve(repo, "package.json"));
+
+const postcss = require("postcss");
+const tailwind = require("@tailwindcss/postcss");
+
+const inputPath = resolve(repo, "src/App.css");
+const css = readFileSync(inputPath, "utf8");
+
+const result = await postcss([tailwind()]).process(css, { from: inputPath });
+
+// The app serves fonts from web root ("/Inter-Font.ttf"); make it local to the
+// stylesheet so the converter resolves + ships it into fonts/.
+copyFileSync(resolve(repo, "public/Inter-Font.ttf"), resolve(here, "Inter-Font.ttf"));
+const out = result.css.replaceAll('url("/Inter-Font.ttf")', 'url("./Inter-Font.ttf")');
+
+const outPath = resolve(here, "quadrant-compiled.css");
+writeFileSync(outPath, out);
+console.error(`compiled ${(out.length / 1024).toFixed(0)} KB → ${outPath}`);

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,30 @@
+{
+  "projectId": "ff456d7a-1ec1-478b-b934-dd85a6b89139",
+  "shape": "package",
+  "pkg": "quadrant-next",
+  "globalName": "Quadrant",
+  "srcDir": "src",
+  "tsconfig": ".design-sync/tsconfig.sync.json",
+  "cssEntry": ".design-sync/quadrant-compiled.css",
+  "readmeHeader": ".design-sync/conventions.md",
+  "entry": ".design-sync/ds-entry.tsx",
+  "componentSrcMap": {
+    "Button": "src/components/core/Button.tsx",
+    "CircularProgress": "src/components/core/CircularProgress.tsx",
+    "LinearProgress": "src/components/core/LinearProgress.tsx",
+    "Mod": "src/components/shared/Mod.tsx",
+    "Notifications": "src/components/shared/Notifications.tsx",
+    "LoaderOption": "src/components/shared/LoaderOption.tsx",
+    "ModpackView": "src/components/shared/Pages/ModpackView.tsx",
+    "AccountPage": "src/components/Pages/AccountPage/AccountPage.tsx",
+    "ApplyPage": "src/components/Pages/ApplyPage/Apply.tsx",
+    "CurrentModpackPage": "src/components/Pages/CurrentModpackPage/CurrentModpackPage.tsx",
+    "ModInstallPage": "src/components/Pages/ModInstallPage/ModInstallPage.tsx",
+    "SearchPage": "src/components/Pages/SearchPage/SearchPage.tsx",
+    "SettingsPage": "src/components/Pages/SettingsPage/Settings.tsx",
+    "SharePage": "src/components/Pages/ShareSyncPage/SharePage.tsx",
+    "ShareSyncPage": "src/components/Pages/ShareSyncPage/ShareSyncPage.tsx",
+    "SyncPage": "src/components/Pages/ShareSyncPage/SyncPage.tsx",
+    "SyncedModpack": "src/components/Pages/ShareSyncPage/SyncedModpack/SyncedModpack.tsx"
+  }
+}

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,62 @@
+## Building with Quadrant UI
+
+Quadrant is a desktop (Tauri) app for managing Minecraft mods and modpacks. Its
+UI is **React 19 + Tailwind CSS v4**, dark-themed, with an Inter typeface. Build
+with these real components; style your own layout glue with the Tailwind classes
+below.
+
+### Setup — usually nothing
+
+- Components render standalone. i18n is initialized by the bundle, so text
+  renders in English automatically — no provider needed.
+- **Data comes from props, not the backend.** In the app these components fetch
+  data through a desktop runtime (`invoke`) that does **not** exist outside the
+  Tauri shell — calling it throws "Quadrant desktop runtime is unavailable". So
+  when you compose a screen, **pass data in as props** (a `Mod`'s metadata, a
+  modpack list) rather than expecting it to load itself. Page components
+  (`SettingsPage`, `AccountPage`, `SharePage`, …) paint their chrome fine; their
+  live data lists stay empty in a design environment.
+- The Share/Sync flow shares state through `ShareSyncPage`'s context — render
+  `SharePage`, `SyncPage`, `SyncedModpack` **inside `ShareSyncPage`**, not alone.
+
+### Styling idiom — Tailwind v4 utilities
+
+There is **no separate CSS API**: style everything with Tailwind utility classes
+(the same ones the app uses). The palette is slate-based dark:
+
+| Purpose | Classes |
+|---|---|
+| App background / surfaces | `bg-slate-900` (page), `bg-slate-800` / `bg-slate-700` (cards, inputs) |
+| Text | `text-slate-50` (default), `text-slate-400` (muted) |
+| Primary action | `bg-blue-600 hover:bg-blue-700` |
+| Positive / create | `bg-emerald-600 hover:bg-emerald-700` |
+| Neutral action | `bg-slate-800 hover:bg-slate-700` |
+| Destructive | `bg-slate-800 hover:bg-red-700` |
+| Rounding | `rounded-full` / `rounded-4xl` (pills everywhere) |
+| Type | Inter, `font-normal`; `font-extrabold` on buttons |
+
+Custom classes shipped in the stylesheet: `.input` (styled text field),
+`.center` (grid place-items-center), `.page` (full-width), `.disableSelect`.
+Icons come from `react-icons` (e.g. `react-icons/fa6`).
+
+### Where the real detail lives
+
+Read the bound stylesheet `styles.css` (and its `@import`ed `_ds_bundle.css` /
+`tokens/`) for exact tokens, and each component's `<Name>.d.ts` (props) and
+`<Name>.prompt.md` (usage) before composing.
+
+### Idiomatic snippet
+
+```tsx
+import { Button } from "quadrant-next";
+import { FaPlus } from "react-icons/fa6";
+
+<div className="bg-slate-900 p-6 flex gap-3">
+  <Button className="bg-emerald-600 hover:bg-emerald-700 text-slate-50" onClick={createModpack}>
+    <span className="flex items-center gap-2"><FaPlus /> Create a new modpack</span>
+  </Button>
+  <Button className="bg-slate-800 hover:bg-slate-700 text-slate-50" onClick={openFolder}>
+    Open modpacks folder
+  </Button>
+</div>
+```

--- a/.design-sync/ds-entry.tsx
+++ b/.design-sync/ds-entry.tsx
@@ -1,0 +1,30 @@
+/**
+ * design-sync barrel entry.
+ * All Quadrant components are default exports; this re-exports them as named
+ * exports so the converter can assign each to window.Quadrant.<Name>.
+ * Referenced by cfg.entry — committed so re-sync is reproducible.
+ *
+ * Importing src/i18n runs its init side-effect (react-i18next uses a global
+ * instance, no provider needed), so components render real translated copy.
+ */
+import "../src/i18n";
+
+export { default as Button } from "../src/components/core/Button";
+export { default as CircularProgress } from "../src/components/core/CircularProgress";
+export { default as LinearProgress } from "../src/components/core/LinearProgress";
+
+export { default as Mod } from "../src/components/shared/Mod";
+export { default as Notifications } from "../src/components/shared/Notifications";
+export { default as LoaderOption } from "../src/components/shared/LoaderOption";
+export { default as ModpackView } from "../src/components/shared/Pages/ModpackView";
+
+export { default as AccountPage } from "../src/components/Pages/AccountPage/AccountPage";
+export { default as ApplyPage } from "../src/components/Pages/ApplyPage/Apply";
+export { default as CurrentModpackPage } from "../src/components/Pages/CurrentModpackPage/CurrentModpackPage";
+export { default as ModInstallPage } from "../src/components/Pages/ModInstallPage/ModInstallPage";
+export { default as SearchPage } from "../src/components/Pages/SearchPage/SearchPage";
+export { default as SettingsPage } from "../src/components/Pages/SettingsPage/Settings";
+export { default as SharePage } from "../src/components/Pages/ShareSyncPage/SharePage";
+export { default as ShareSyncPage } from "../src/components/Pages/ShareSyncPage/ShareSyncPage";
+export { default as SyncPage } from "../src/components/Pages/ShareSyncPage/SyncPage";
+export { default as SyncedModpack } from "../src/components/Pages/ShareSyncPage/SyncedModpack/SyncedModpack";

--- a/.design-sync/previews/Button.tsx
+++ b/.design-sync/previews/Button.tsx
@@ -1,0 +1,51 @@
+// Authored preview for Quadrant's Button. Each export = one card cell.
+import { Button } from "quadrant-next";
+import { FaDownload, FaPlus, FaTrash } from "react-icons/fa6";
+
+const noop = () => {};
+
+export function Primary() {
+  return (
+    <div className="p-6 bg-slate-900">
+      <Button className="bg-blue-600 hover:bg-blue-700 text-slate-50" onClick={noop}>
+        Sign in via OAuth
+      </Button>
+    </div>
+  );
+}
+
+export function Variants() {
+  return (
+    <div className="p-6 bg-slate-900 flex flex-wrap gap-3 items-center">
+      <Button className="bg-blue-600 hover:bg-blue-700 text-slate-50" onClick={noop}>
+        Primary
+      </Button>
+      <Button className="bg-emerald-600 hover:bg-emerald-700 text-slate-50" onClick={noop}>
+        <span className="flex items-center gap-2">
+          <FaPlus /> Create a new modpack
+        </span>
+      </Button>
+      <Button className="bg-slate-800 hover:bg-slate-700 text-slate-50" onClick={noop}>
+        Neutral
+      </Button>
+      <Button className="bg-slate-800 hover:bg-red-700 text-slate-50" onClick={noop}>
+        <span className="flex items-center gap-2">
+          <FaTrash /> Delete your usage data
+        </span>
+      </Button>
+    </div>
+  );
+}
+
+export function IconRound() {
+  return (
+    <div className="p-6 bg-slate-900 flex gap-3 items-center">
+      <Button fullRound className="bg-blue-600 hover:bg-blue-700 text-slate-50 px-3" onClick={noop}>
+        <FaDownload />
+      </Button>
+      <Button fullRound animate className="bg-emerald-600 hover:bg-emerald-700 text-slate-50 px-3" onClick={noop}>
+        <FaPlus />
+      </Button>
+    </div>
+  );
+}

--- a/.design-sync/tsconfig.sync.json
+++ b/.design-sync/tsconfig.sync.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "tailwindcss": ["./tw-shim.css"]
+    }
+  }
+}

--- a/.design-sync/tw-shim.css
+++ b/.design-sync/tw-shim.css
@@ -1,0 +1,2 @@
+/* design-sync shim: neutralizes `@import "tailwindcss"` in component CSS.
+   Real utilities are delivered via the compiled global stylesheet (cfg.cssEntry). */

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,10 @@ src-tauri/versoview
 target/
 AppxContent
 AppxBundles
+.ds-sync/
+ds-bundle/
+.design-sync/.cache/
+.design-sync/learnings/
+.design-sync/node_modules
+.design-sync/quadrant-compiled.css
+.design-sync/Inter-Font.ttf


### PR DESCRIPTION
Sync inputs for importing Quadrant's React components into a Claude Design project (window.Quadrant). Since this is a Tauri app (not a published component library), the pipeline is wired by hand:

- ds-entry.tsx: barrel re-exporting all 17 default-exported components as named exports + i18n init side-effect.
- build-css.mjs: compiles src/App.css via the repo's Tailwind v4 postcss into the shipped global stylesheet.
- tsconfig.sync.json + tw-shim.css: redirect the bare `tailwindcss` CSS import so esbuild can bundle component CSS.
- config.json / conventions.md / NOTES.md / previews/Button.tsx.

Generated outputs (compiled CSS, font copy, caches) are gitignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new preview coverage for key UI controls, making design reviews and visual checks easier.
  * Improved support for consistent UI synchronization across app screens and shared views.

* **Documentation**
  * Added detailed guidance for the app’s design-sync workflow, styling conventions, and resync steps.
  * Documented known rendering gaps and areas to watch during future syncs.

* **Chores**
  * Updated generated-file handling so sync-related artifacts are kept out of version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->