### PR TITLE
Fix Sync tab sharing submitting a V1 modpack manifest

### DIFF
--- a/src-tauri/crates/quadrant-host/src/lib.rs
+++ b/src-tauri/crates/quadrant-host/src/lib.rs
@@ -891,8 +891,12 @@ impl QuadrantHost {
 
     pub async fn share_modpack_raw(
         &self,
-        mod_config: InstalledModpack,
+        mut mod_config: InstalledModpack,
     ) -> Result<QuadrantShareSubmissionResponse> {
+        // Renderer-built configs (e.g. the Sync tab) omit the manifest metadata,
+        // which serde otherwise defaults to a V1 config.
+        mod_config.mod_config_version = "2".to_string();
+        mod_config.quadrant_version = quadrant_core::models::quadrant_version();
         let response = share_modpack_raw(
             &self.inner.config_store,
             &self.inner.secret_store,


### PR DESCRIPTION
## What changed

`QuadrantHost::share_modpack_raw` now normalizes the outgoing manifest before submission: it sets `modConfigVersion` to `"2"` and `quadrantVersion` to the running app version.

## Why

Sharing a modpack from the Sync tab builds the `InstalledModpack` object in the renderer (`SyncedModpack.tsx`) with only `name`, `mods`, `modLoader`, and `version`. When the backend deserialized it, the missing fields fell back to serde defaults — `modConfigVersion: "1"` and an empty `quadrantVersion` — so a V1-shaped config was submitted to Quadrant Share instead of modConfigV2.

## Notes for review

- The named-share path (`share_modpack` → `LocalModpack::into()`) already stamped version 2, so re-stamping there is a no-op; the fix lives in the raw path so every caller is covered.
- Verified with `cargo check -p quadrant-host`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)