### PR TITLE
Fix modpack collaboration invites not being recognized

### DIFF
--- a/src/components/shared/Notifications.tsx
+++ b/src/components/shared/Notifications.tsx
@@ -191,7 +191,7 @@ function Notifications({
   const visibleNotifications = notifications.filter((notification) => {
     const detailedMessage = parseNotificationMessage(notification.message);
     const messageType =
-      notification.notification_type ?? detailedMessage?.notification_type;
+      detailedMessage?.notification_type ?? notification.notification_type;
 
     if (messageType !== "modpack_sync") {
       return true;
@@ -327,8 +327,8 @@ function Notifications({
                         notification.message,
                       );
                       const messageType =
-                        notification.notification_type ??
-                        detailedMessage?.notification_type;
+                        detailedMessage?.notification_type ??
+                        notification.notification_type;
                       let message =
                         detailedMessage?.simple_message ??
                         notification.message ??
@@ -350,19 +350,25 @@ function Notifications({
                         </>
                       );
 
-                      if (
-                        messageType == "invite_to_sync" &&
-                        detailedMessage?.message &&
-                        detailedMessage?.invite_id
-                      ) {
-                        const inviteId = detailedMessage.invite_id;
-                        const inviter = (
-                          detailedMessage.message as string
-                        ).split(
-                          "You have been invited to collaborate on a modpack by ",
-                        )[1];
+                      const inviteId =
+                        detailedMessage?.invite_id ??
+                        notification.resource_id ??
+                        undefined;
+
+                      if (messageType == "invite_to_sync" && inviteId) {
+                        const inviteMessage =
+                          detailedMessage?.message ??
+                          detailedMessage?.simple_message ??
+                          notification.message;
+                        const inviter = inviteMessage
+                          ? inviteMessage
+                              .split(
+                                "You have been invited to collaborate on a modpack by ",
+                              )[1]
+                              ?.trim()
+                          : undefined;
                         message = t("invited", {
-                          name: inviter,
+                          name: inviter ?? "",
                         });
                         action = (
                           <>


### PR DESCRIPTION
## Problem

Collaboration invites were never shown as actionable in the notifications panel. Instead of Accept/Decline buttons, users saw the plain fallback text and a single **Read** button:

> You have been invited to collaborate on a modpack by Dolboeb, open this notification in Quadrant v24.7 or higher in order to accept or decline this proposition.

## Root cause

This is a **client** bug, not a backend one. A real invite notification (from `/api/v3/account/notifications/get`) looks like:

```jsonc
{
  "notification_type": "generic",   // top-level bucket
  "resource_id": null,
  "message": "{
      \"notification_type\": \"invite_to_sync\",   // real, actionable type
      \"invite_id\": \"019f515b-1573-70d3-b12e-29a019b7fa81\",
      \"message\": \"You have been invited to collaborate on a modpack by Dolboeb\",
      \"simple_message\": \"...open this notification in Quadrant v24.7 or higher...\",
      \"admin\": false
  }"
}
```

The actionable `notification_type` (`invite_to_sync`), `invite_id`, and human `message` are nested inside the `message` payload; `simple_message` is the graceful fallback for clients that don't parse it.

`Notifications.tsx` derived the type as:

```js
notification.notification_type ?? detailedMessage?.notification_type
```

Since `??` only falls back on `null`/`undefined`, the non-null top-level `"generic"` **shadowed** the nested `"invite_to_sync"`, so the invite branch never fired and only the `simple_message` fallback rendered.

## Fix

- Prefer the message-embedded `notification_type` over the top-level column in both the visibility filter and the render path (`detailedMessage?.notification_type ?? notification.notification_type`). This is also correct for `modpack_sync`, whose type is likewise embedded in the payload.
- Resolve the invite id from `invite_id`, falling back to top-level `resource_id`.
- Harden inviter-name extraction so a missing `message` field no longer throws.

Traced against the real payload above, `messageType` now resolves to `invite_to_sync` and `inviteId` to the nested `invite_id`, so Accept/Decline render as intended.

`tsc --noEmit` and `eslint` are clean.

## Note / follow-up (out of scope)

The Accept/Decline handler passes `invite_id` into `answerInvite`, which reaches `POST /quadrant/sync/respond` in its `modpack_id` field. If the backend expects the actual modpack id there rather than the invite id, Accept may fail even though the buttons now appear. This is pre-existing behavior and unverified (would require a state-changing call on a live account) — flagging for a separate check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)